### PR TITLE
Caching in isotope image handler

### DIFF
--- a/docker/webapp/environment.yml
+++ b/docker/webapp/environment.yml
@@ -32,4 +32,4 @@ dependencies:
     - supervisor
     - pyyaml
     - elasticsearch
-    - functools32
+    - cachetools

--- a/docker/webapp/environment.yml
+++ b/docker/webapp/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - pip:
     - pyMSpec
     - pyImagingMSpec
-    - cpyMSpec
+    - cpyMSpec==0.1.4
     - cpyImagingMSpec
     - py4j==0.9
     - tornado==4.2.1
@@ -32,3 +32,4 @@ dependencies:
     - supervisor
     - pyyaml
     - elasticsearch
+    - functools32

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ recommonmark
 pandas>=0.18
 boto3>=1.3.0
 networkx>=1.11
-functools32
+cachetools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pyImagingMSpec
 cpyImagingMSpec
 pyMSpec
-cpyMSpec
+cpyMSpec==0.1.4
 requests
 numpy>=1.10.4
 Fabric>=1.10.2
@@ -20,3 +20,4 @@ recommonmark
 pandas>=0.18
 boto3>=1.3.0
 networkx>=1.11
+functools32

--- a/sm/webapp/handlers/iso_image_gen.py
+++ b/sm/webapp/handlers/iso_image_gen.py
@@ -9,7 +9,7 @@ import matplotlib.cm as cm
 from matplotlib.colors import Normalize
 import cStringIO
 import png
-from functools32 import lru_cache
+from cachetools import LRUCache, cached, hashkey
 
 
 INTS_SQL = ('SELECT pixel_inds inds, intensities as ints '
@@ -24,6 +24,51 @@ BOUNDS_SEL = ('SELECT img_bounds '
               'WHERE j.id=%s')
 COORD_SEL = "SELECT xs, ys FROM coordinates WHERE ds_id='%s'"
 
+@cached(cache=LRUCache(maxsize=500), key=lambda db, *args: hashkey(*args))
+def _get_intens_list(db, job_id, db_id, sf_id, adduct, shape):
+    res_list_rows = db.query(INTS_SQL, job_id, db_id, sf_id, adduct)
+    intens_list = []
+    for res_row in res_list_rows:
+        img_arr = np.zeros(shape[0] * shape[1])
+        img_arr[res_row.inds] = res_row.ints
+
+        # smoothing extreme values
+        non_zero_intens = img_arr > 0
+        if any(non_zero_intens) > 0:
+            perc99_val = np.percentile(img_arr[non_zero_intens], 99)
+            img_arr[img_arr > perc99_val] = perc99_val
+
+        intens_list.append(img_arr.reshape(shape))
+
+    return np.array(intens_list)
+
+@cached(cache={}, key=lambda db, ds_id: hashkey(ds_id))
+def _get_coords(db, ds_id):
+    coords_row = db.query(COORD_SEL % ds_id)[0]
+    coords = np.array(zip(coords_row.xs, coords_row.ys))
+    coords -= coords.min(axis=0)
+    shape = coords.max(axis=0) + 1
+    shape = (shape[1], shape[0])
+
+    rows = coords[:, 1]
+    cols = coords[:, 0]
+    data = np.ones(coords.shape[0])
+    mask = coo_matrix((data, (rows, cols)), shape=shape).toarray() > 0
+
+    return coords, shape, mask
+
+@cached(cache={}, key=lambda db, job_id: hashkey(job_id))
+def _get_img_bounds(db, job_id):
+    img_bounds = db.query(BOUNDS_SEL, job_id)[0]['img_bounds']
+    nrows = img_bounds['y']['max'] - img_bounds['y']['min'] + 1
+    ncols = img_bounds['x']['max'] - img_bounds['x']['min'] + 1
+    return nrows, ncols
+
+@cached(cache=LRUCache(maxsize=500), key=lambda db, *args: hashkey(*args))
+def _get_grayscale_image_data(db, ds_id, job_id, db_id, sf_id, adduct):
+    coords, shape, mask = _get_coords(db, ds_id)
+    int_list = _get_intens_list(db, job_id, db_id, sf_id, adduct, shape)
+    return shape, mask, int_list
 
 class IsoImgBaseHandler(tornado.web.RequestHandler):
     # Viridis
@@ -49,52 +94,12 @@ class IsoImgBaseHandler(tornado.web.RequestHandler):
         self.set_header("Content-Type", "image/png")
         self.write(img_fp.getvalue())
 
-    @lru_cache()
-    def _get_intens_list(self, job_id, db_id, sf_id, adduct, shape):
-        res_list_rows = self.db.query(INTS_SQL, job_id, db_id, sf_id, adduct)
-        intens_list = []
-        for res_row in res_list_rows:
-            img_arr = np.zeros(shape[0] * shape[1])
-            img_arr[res_row.inds] = res_row.ints
-
-            # smoothing extreme values
-            non_zero_intens = img_arr > 0
-            if any(non_zero_intens) > 0:
-                perc99_val = np.percentile(img_arr[non_zero_intens], 99)
-                img_arr[img_arr > perc99_val] = perc99_val
-
-            intens_list.append(img_arr.reshape(shape))
-
-        return np.array(intens_list)
-
-    @staticmethod
-    def _get_ds_mask(coords, shape):
-        rows = coords[:, 1]
-        cols = coords[:, 0]
-        data = np.ones(coords.shape[0])
-        return coo_matrix((data, (rows, cols)), shape=shape).toarray() > 0
-
     def get_img_ints(self, ints_list):
         pass
 
-    @lru_cache()
-    def _get_coords(self, ds_id):
-        coords_row = self.db.query(COORD_SEL % ds_id)[0]
-        coords = np.array(zip(coords_row.xs, coords_row.ys))
-        coords -= coords.min(axis=0)
-        shape = coords.max(axis=0) + 1
-        return coords, (shape[1], shape[0])
-
-    @lru_cache()
-    def _get_grayscale_image_data(self, ds_id, job_id, db_id, sf_id, adduct):
-        coords, shape = self._get_coords(ds_id)
-        mask = self._get_ds_mask(coords, shape)
-        int_list = self._get_intens_list(job_id, db_id, sf_id, adduct, shape)
-        return shape, mask, int_list
-
     # TODO: get rid of matplotlib
     def _get_color_image_data(self, ds_id, job_id, db_id, sf_id, adduct):
-        shape, mask, int_list = self._get_grayscale_image_data(ds_id, job_id, db_id, sf_id, adduct)
+        shape, mask, int_list = _get_grayscale_image_data(self.db, ds_id, job_id, db_id, sf_id, adduct)
         self.nrows, self.ncols = shape
         if int_list.size > 0:
             visible_pixels = self.get_img_ints(int_list)
@@ -106,9 +111,7 @@ class IsoImgBaseHandler(tornado.web.RequestHandler):
         return color_img_data
 
     def gen_iso_img(self, ds_id, job_id, sf_id, adduct, color_img_data):
-        img_bounds = self.db.query(BOUNDS_SEL, job_id)[0]['img_bounds']
-        nrows = img_bounds['y']['max'] - img_bounds['y']['min'] + 1
-        ncols = img_bounds['x']['max'] - img_bounds['x']['min'] + 1
+        nrows, ncols = _get_img_bounds(self.db, job_id)
 
         fp = cStringIO.StringIO()
         png_writer = png.Writer(width=ncols, height=nrows, alpha=True)
@@ -125,10 +128,12 @@ class IsoImgPngHandler(IsoImgBaseHandler):
     @gen.coroutine
     def get(self, db_id, ds_id, job_id, sf_id, sf, adduct, peak_id):
         self.peak_id = int(peak_id)
+        job_id = int(job_id)
+        sf_id = int(sf_id)
 
         color_img_data = self._get_color_image_data(ds_id, job_id, db_id, sf_id, adduct)
         if color_img_data[:,:,:3].sum() > 0:
-            img_fp = self.gen_iso_img(ds_id, int(job_id), int(sf_id), adduct, color_img_data)
+            img_fp = self.gen_iso_img(ds_id, job_id, sf_id, adduct, color_img_data)
             self.send_img_response(img_fp)
         else:
             self.redirect('/static/iso_placeholder.png')

--- a/sm/webapp/handlers/iso_image_gen.py
+++ b/sm/webapp/handlers/iso_image_gen.py
@@ -95,6 +95,7 @@ class IsoImgBaseHandler(tornado.web.RequestHandler):
     # TODO: get rid of matplotlib
     def _get_color_image_data(self, ds_id, job_id, db_id, sf_id, adduct):
         shape, mask, int_list = self._get_grayscale_image_data(ds_id, job_id, db_id, sf_id, adduct)
+        self.nrows, self.ncols = shape
         if int_list.size > 0:
             visible_pixels = self.get_img_ints(int_list)
             normalizer = Normalize(vmin=np.min(visible_pixels), vmax=np.max(visible_pixels))


### PR DESCRIPTION
Intensities and coordinates are currently re-fetched from the database for every isotopic image.

This PR introduces usage of `functools32` module for LRU caching of the most expensive method calls to avoid doing double work.